### PR TITLE
Fixed misuse of rstrip in text_value()

### DIFF
--- a/urpaform/elements.py
+++ b/urpaform/elements.py
@@ -89,7 +89,7 @@ class EditElement(_FormElement):
         if self.value_is_in == "name":
             return self.element.name()
         if self.value_is_in == "text_value":
-            return self.element.text_value().rstrip("\n")
+            return self.element.text_value()[:-1]
         return ""
 
     @value.setter


### PR DESCRIPTION
In java applications, there is always last char new line. I replaced using rstrip() for slicing string [:-1] with removing the last char, which is a new line.